### PR TITLE
feature: Streamline build pipeline to only run lint and build checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Package
+name: Build and Lint
 
 on:
   push:
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-web:
-    name: Build Web Application
+  build-and-lint:
+    name: Build and Lint
     runs-on: ubuntu-latest
 
     steps:
@@ -25,68 +25,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build web application
+      - name: Run linter
+        run: npm run lint
+
+      - name: Build application
         run: npm run build
-
-      - name: Upload web build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: web-build
-          path: dist/
-          retention-days: 7
-
-  build-electron:
-    name: Build Electron - ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: ".node-version"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Package Electron app
-        run: npm run package
-
-      - name: Create distributables
-        run: npm run make
-
-      - name: Upload Windows artifacts
-        if: matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: electron-windows
-          path: |
-            out/make/squirrel.windows/**/*.exe
-            out/make/squirrel.windows/**/*.nupkg
-          retention-days: 30
-
-      - name: Upload macOS artifacts
-        if: matrix.os == 'macos-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: electron-macos
-          path: |
-            out/make/zip/**/*.zip
-          retention-days: 30
-
-      - name: Upload Linux artifacts
-        if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: electron-linux
-          path: |
-            out/make/deb/**/*.deb
-            out/make/rpm/**/*.rpm
-          retention-days: 30


### PR DESCRIPTION
Remove expensive cross-platform Electron packaging from the build pipeline since it duplicates work done by the release pipeline. The build pipeline now focuses on quick quality checks (linting + TypeScript compilation) for every PR and main branch push.
