### PR TITLE
feature: Add application version to page title

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,10 @@ import { CheckCircleIcon, BoltIcon, PauseCircleIcon, ExclamationTriangleIcon, Ar
 import './App.css';
 
 function App() {
+  // Set page title with version
+  useEffect(() => {
+    document.title = `Respira v${__APP_VERSION__}`;
+  }, []);
   // Machine store
   const {
     isConnected,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -4,7 +4,12 @@ import { viteStaticCopy } from 'vite-plugin-static-copy'
 import tailwindcss from '@tailwindcss/vite'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
+import { readFileSync } from 'fs'
 import type { Plugin } from 'vite'
+
+// Read version from package.json
+const packageJson = JSON.parse(readFileSync('./package.json', 'utf-8'))
+const appVersion = packageJson.version
 
 const PYODIDE_EXCLUDE = [
   '!**/*.{md,html}',
@@ -133,6 +138,9 @@ export function downloadPyPIWheels(packages: PyPIPackage[]): Plugin {
 
 // https://vite.dev/config/
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+  },
   plugins: [
     react(),
     tailwindcss(),


### PR DESCRIPTION
- Read version from package.json at build time using Vite define
- Create global __APP_VERSION__ constant injected by Vite
- Update document title in App component to include version (e.g., "Respira v0.0.0")
- Works reliably in both web and Electron builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)