### PR TITLE
fix: Remove module-level side effect from useMachineStore initialization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { useShallow } from "zustand/react/shallow";
+import { useMachineStore } from "./stores/useMachineStore";
 import { useMachineCacheStore } from "./stores/useMachineCacheStore";
 import { usePatternStore } from "./stores/usePatternStore";
 import { useUIStore } from "./stores/useUIStore";
@@ -21,6 +22,11 @@ function App() {
   // Set page title with version
   useEffect(() => {
     document.title = `Respira v${__APP_VERSION__}`;
+  }, []);
+
+  // Initialize machine store subscriptions (once on mount)
+  useEffect(() => {
+    useMachineStore.getState().initialize();
   }, []);
 
   // Machine cache store - for auto-loading cached pattern

--- a/src/stores/useMachineStore.ts
+++ b/src/stores/useMachineStore.ts
@@ -57,6 +57,9 @@ interface MachineState {
   resumeSewing: () => Promise<void>;
   deletePattern: () => Promise<void>;
 
+  // Initialization
+  initialize: () => void;
+
   // Internal methods
   _setupSubscriptions: () => void;
   _startPolling: () => void;
@@ -309,6 +312,11 @@ export const useMachineStore = create<MachineState>((set, get) => ({
     }
   },
 
+  // Initialize the store (call once from App component)
+  initialize: () => {
+    get()._setupSubscriptions();
+  },
+
   // Setup service subscriptions
   _setupSubscriptions: () => {
     const { service } = get();
@@ -420,9 +428,6 @@ export const useMachineStore = create<MachineState>((set, get) => ({
     }
   },
 }));
-
-// Initialize subscriptions when store is created
-useMachineStore.getState()._setupSubscriptions();
 
 // Selector hooks for common use cases
 export const useIsConnected = () =>


### PR DESCRIPTION
## Problem

Store initialization was happening at module load via side effect:
```typescript
useMachineStore.getState()._setupSubscriptions();
```

This caused several issues:
- Executed before app was ready
- Made testing difficult (runs before test setup)
- Hard to control initialization timing
- Could cause issues in different environments

## Solution

- Added public `initialize()` method to useMachineStore
- Call initialization from App component's useEffect (proper lifecycle)
- Removed module-level side effect

## Benefits

- ✅ Controlled initialization timing
- ✅ Better testability (no side effects on import)
- ✅ Follows React lifecycle patterns
- ✅ No behavioral changes for end users

## Testing

- Build tested successfully
- Linter passed
- All TypeScript types validated

Fixes #38